### PR TITLE
Changed from Object to BaseObject as new version of PHP doesn't allow…

### DIFF
--- a/src/JsUrlManager.php
+++ b/src/JsUrlManager.php
@@ -4,7 +4,7 @@ namespace dmirogin\js\urlmanager;
 
 use Yii;
 use yii\base\BootstrapInterface;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\Json;
 use yii\base\Application;
 use yii\web\JsExpression;
@@ -19,7 +19,7 @@ use yii\web\View;
  *
  * @author Dmitry Dorogin <dmirogin@ya.ru>
  */
-class JsUrlManager extends Object implements BootstrapInterface
+class JsUrlManager extends BaseObject implements BootstrapInterface
 {
     /**
      * The location to register configuration Frontend UrlManager string


### PR DESCRIPTION
Yii2 was update an version 2.0.13.3 doesn't have class Object anymore.
Php 7.2 also don't allows to have a class with name Object.

Please accept my pull request to be merged into master.